### PR TITLE
Add cache_version for cache busting

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -38,14 +38,15 @@ def require_login():
 
 @manager_bp.route("/login", methods=["GET", "POST"])
 def login():
+    cache_version = int(time.time())
     if request.method == "POST":
         username = request.form.get("username")
         password = request.form.get("password")
         if username == "admin" and password == "admin123":
             session['user_logged_in'] = True
             return redirect(url_for("manager_bp.index"))
-        return render_template("login.html", error="Invalid credentials")
-    return render_template("login.html")
+        return render_template("login.html", error="Invalid credentials", cache_version=cache_version)
+    return render_template("login.html", cache_version=cache_version)
 
 @manager_bp.route("/logout")
 def logout():
@@ -108,7 +109,8 @@ def create_button(folder_name):
 def index():
     buttons_data = load_buttons()
     buttons = [(info["button_name"], folder, info["image"]) for folder, info in buttons_data.items()]
-    return render_template("index.html", buttons=buttons)
+    cache_version = int(time.time())
+    return render_template("index.html", buttons=buttons, cache_version=cache_version)
 
 @manager_bp.route("/upload", methods=["POST"])
 def upload():

--- a/app.py
+++ b/app.py
@@ -40,14 +40,15 @@ def require_login():
 
 @manager_bp.route('/login', methods=['GET', 'POST'])
 def login():
+    cache_version = int(time.time())
     if request.method == "POST":
         username = request.form.get("username")
         password = request.form.get("password")
         if username == "admin" and password == "admin123":
             session['user_logged_in'] = True
             return redirect(url_for("manager_bp.index"))
-        return render_template("login.html", error="Invalid credentials")
-    return render_template("login.html")
+        return render_template("login.html", error="Invalid credentials", cache_version=cache_version)
+    return render_template("login.html", cache_version=cache_version)
 
 @manager_bp.route("/logout")
 def logout():
@@ -133,7 +134,8 @@ def serve_app_logo(app_name, image_filename):
 def index():
     buttons_data = load_buttons()
     buttons = [(info["button_name"], folder, info["image"]) for folder, info in buttons_data.items()]
-    return render_template("index.html", buttons=buttons)
+    cache_version = int(time.time())
+    return render_template("index.html", buttons=buttons, cache_version=cache_version)
 
 @manager_bp.route('/upload', methods=['POST'])
 def upload():

--- a/templates/login.html
+++ b/templates/login.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>Login - Bot Manager</title>
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}?v={{ cache_version }}">
 </head>
 <body class="login-page">
   <div class="login-container">


### PR DESCRIPTION
## Summary
- compute `cache_version = int(time.time())` when rendering templates
- append `cache_version` to asset URLs in `login.html`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68515ef642208331be399550189f3009